### PR TITLE
transmit pkt_pos/pkt_size and output doi

### DIFF
--- a/source/decoder/uavs3d.c
+++ b/source/decoder/uavs3d.c
@@ -780,6 +780,10 @@ int init_dec_frm(uavs3d_dec_t *ctx, com_frm_t *frm, uavs3d_io_frm_t *frm_io)
     pic->dtr = pichdr->decode_order_index;
     pic->type = pichdr->slice_type;
 
+    pic->pkt_pos  = frm_io->pkt_pos;
+    pic->pkt_size = frm_io->pkt_size;
+    pic->doi      = frm->pichdr.decode_order_index + (DOI_CYCLE_LENGTH * (int)ctx->pic_manager.doi_cycles);
+
     for (int i = 0; i < frm->num_refp[REFP_0]; i++) {
         pic->refpic[REFP_0][i] = frm->refp[i][REFP_0].pic->ptr;
     }
@@ -849,6 +853,10 @@ int uavs3d_output_frame(void *id, uavs3d_io_frm_t *frm, int flush, uavs3d_lib_ou
             frm->pts  = pic->pts;
             frm->dts  = pic->dts;
             frm->type = pic->type;
+
+            frm->pkt_pos  = pic->pkt_pos;
+            frm->pkt_size = pic->pkt_size;
+            frm->doi      = pic->doi;
 
             frm->refpic_num[0] = pic->refpic_num[0];
             frm->refpic_num[1] = pic->refpic_num[1];

--- a/source/decoder/uavs3d.h
+++ b/source/decoder/uavs3d.h
@@ -232,6 +232,10 @@ typedef struct uavs3d_io_frm_t {
     int         refpic_num[2];
     long long   refpic[2][16];
 
+    long long   pkt_pos;
+    int         pkt_size;
+    int         doi;
+
     /* bitstream */
     unsigned char *bs;
     int bs_len;

--- a/source/decore/com_type.h
+++ b/source/decore/com_type.h
@@ -77,6 +77,10 @@ typedef struct uavs3d_com_pic_t {
     int        refpic_num[2];
     long long  refpic[2][16];
 
+    long long  pkt_pos;
+    int        pkt_size;
+    int        doi;
+
     /*** for parallel ***/
     int                     parallel_enable;
     int                     finished_line;


### PR DESCRIPTION
传递帧在码流中的位置pkt_pos及大小pkt_size，输出解码序doi和显示序ptr，用于传递给ffmpeg AVFrame中的pkt_pos/pkt_size和coded_picture_number/display_picture_number