### PR TITLE
Fix 32-bit compile on Windows and use CMake's way of setting std and fPIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 
 project(uavs3d)
 
+set(CMAKE_C_STANDARD 99)
+
 aux_source_directory(./test DIR_SRC_TEST)
-set_source_files_properties(${DIR_SRC_TEST} PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -std=c99 -O3")
 
 add_subdirectory(./source)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.1)
 project(uavs3d)
 
 set(CMAKE_C_STANDARD 99)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 aux_source_directory(./test DIR_SRC_TEST)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
 
 project(uavs3d)
 
@@ -12,4 +12,3 @@ add_executable(uavs3dec ${DIR_SRC_TEST})
 target_link_libraries(uavs3dec m)
 target_link_libraries(uavs3dec uavs3d)
 #target_link_libraries(uavs3dec dl)
-

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -31,15 +31,14 @@ aux_source_directory(./decore DIR_UAVS3D_CORE)
 list(APPEND DIR_UAVS3D_SRC ${DIR_UAVS3D_CORE})
 
 include_directories("decore")
-set_source_files_properties(${DIR_UAVS3D_SRC} PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=c99 -O3")
 set(UAVS3D_ASM_FILES "")
 
-if("${UAVS3D_TARGET_CPU}" MATCHES "x86" OR 
+if("${UAVS3D_TARGET_CPU}" MATCHES "x86" OR
    "${UAVS3D_TARGET_CPU}" MATCHES "x86_64")
   aux_source_directory(./decore/sse DIR_X86_SRC)
   aux_source_directory(./decore/avx2 DIR_X86_256_SRC)
-  set_source_files_properties(${DIR_X86_SRC} PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=c99 -O3 -msse4.2")
-  set_source_files_properties(${DIR_X86_256_SRC} PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=c99 -O3 -mavx2")
+  set_source_files_properties(${DIR_X86_SRC} PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -msse4.2")
+  set_source_files_properties(${DIR_X86_256_SRC} PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -mavx2")
 
   list(APPEND UAVS3D_ASM_FILES ${DIR_X86_SRC})
   list(APPEND UAVS3D_ASM_FILES ${DIR_X86_256_SRC})
@@ -137,4 +136,3 @@ endif()
 install(TARGETS uavs3d LIBRARY DESTINATION ${CMAKE_INSTALL_LIB_DIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIB_DIR})
 install(FILES decoder/uavs3d.h DESTINATION ${CMAKE_INSTALL_INCLUDE_DIR})
 install(FILES ${CONFIG_DIR}/${LIBNAME}.pc DESTINATION ${CMAKE_INSTALL_PKGCONFIG_DIR})
-

--- a/source/decore/sse/sse.h
+++ b/source/decore/sse/sse.h
@@ -48,7 +48,15 @@
 #ifdef _WIN32
 
 #ifndef _WIN64
-#define _mm_extract_epi64(a, i) (a.m128i_i64[i])
+#include <stdint.h>
+static inline int64_t _mm_extract_epi64(__m128i a, const int imm8) {
+    return imm8 ? ((int64_t)_mm_extract_epi16(a, 7) << 48) |
+                      ((int64_t)_mm_extract_epi16(a, 6) << 32) |
+                      (_mm_extract_epi16(a, 5) << 16) | _mm_extract_epi16(a, 4)
+                : ((int64_t)_mm_extract_epi16(a, 3) << 48) |
+                      ((int64_t)_mm_extract_epi16(a, 2) << 32) |
+                      (_mm_extract_epi16(a, 1) << 16) | _mm_extract_epi16(a, 0);
+}
 #endif
 
 #endif


### PR DESCRIPTION
_mm_extract_epi64: Adding this will require `stdint.h` since on windows, `long long` is required for 64 bits, but `long` is 64-bits on most Linux systems.
The particular system this had an issue with is mingw-w64 i686 gcc compiler and it didn't seem that `__m128i` has a `m128i_i64` field

I would consider cmake 2.8 to be way too low, with a 2.8.12 being the bare minimum (If I remember correctly, the default cmake package on centos 6.7 is 2.8.12, with cmake3 being available), but 3.1 is required for [`CMAKE_C_STANDARD`](https://cmake.org/cmake/help/v3.1/variable/CMAKE_C_STANDARD.html) and [`CMAKE_POSITION_INDEPENDENT_CODE`](https://cmake.org/cmake/help/v3.1/variable/CMAKE_POSITION_INDEPENDENT_CODE.html)

I removed the `-O3` since it would apply unconditionally even on debug builds. It would be much better to pass `-DCMAKE_BUILD_TYPE=Release` or `-DCMAKE_BUILD_TYPE=Debug` on the command line to cmake to set `-O3` or `-g` automatically

```bash
cmake -B build -DCMAKE_BUILD_TYPE=Release
```
for example

As an aside, the reason why I removed `-fPIC` and used the variable is because clang on windows will error out on that flag since even though it's a no-op, clang considers it an error.