### PR TITLE
modify android ndk-build scripts

### DIFF
--- a/build/android/ndk/jni/Android.mk
+++ b/build/android/ndk/jni/Android.mk
@@ -5,53 +5,26 @@ SRC_PATH     := ../../../../source
 INCLUDE_PATH := ../../../../source/decore
 
 ### Name of the local module
-include $(CLEAR_VARS) 
+include $(LOCAL_PATH)/uavs3d_clear_vars.mk
+LOCAL_MODULE            := uavs3d-static
+LOCAL_MODULE_FILENAME   := libuavs3d
+include $(LOCAL_PATH)/uavs3d_main.mk
+include $(BUILD_STATIC_LIBRARY)
+
+include $(LOCAL_PATH)/uavs3d_clear_vars.mk
+LOCAL_MODULE            := uavs3d-shared
+LOCAL_MODULE_FILENAME   := libuavs3d
+LOCAL_LDLIBS:=-L$(SYSROOT)/usr/lib -lm -llog
+LOCAL_LDFLAGS   += -fPIC
+include $(LOCAL_PATH)/uavs3d_main.mk
+include $(BUILD_SHARED_LIBRARY)
+
+
+include $(LOCAL_PATH)/uavs3d_clear_vars.mk
 LOCAL_MODULE            := uavs3d
 LOCAL_LDLIBS:=-L$(SYSROOT)/usr/lib -lm -llog
-
-### for posix pthread
-#LOCAL_SHARED_LIBRARIES := libcutil
-
-### include search path when compiling all sources (C,C++,Assembly)
-LOCAL_C_INCLUDES +=$(INCLUDE_PATH)                             \
-                   $(LOCAL_PATH)/../app           
-
-### c source code
-uavs3d_srcs_c   += $(SRC_PATH)/decore/alf.c
-uavs3d_srcs_c   += $(SRC_PATH)/decore/deblock.c
-uavs3d_srcs_c   += $(SRC_PATH)/decore/inter_pred.c
-uavs3d_srcs_c   += $(SRC_PATH)/decore/intra_pred.c
-uavs3d_srcs_c   += $(SRC_PATH)/decore/inv_trans.c
-uavs3d_srcs_c   += $(SRC_PATH)/decore/pic_manager.c
-uavs3d_srcs_c   += $(SRC_PATH)/decore/recon.c
-uavs3d_srcs_c   += $(SRC_PATH)/decore/sao.c
-uavs3d_srcs_c   += $(SRC_PATH)/decore/com_table.c
-uavs3d_srcs_c   += $(SRC_PATH)/decore/threadpool.c
-uavs3d_srcs_c   += $(SRC_PATH)/decore/win32thread.c
-uavs3d_srcs_c   += $(SRC_PATH)/decore/com_util.c
-uavs3d_srcs_c   += $(SRC_PATH)/decoder/uavs3d.c
-uavs3d_srcs_c   += $(SRC_PATH)/decoder/bitstream.c
-uavs3d_srcs_c   += $(SRC_PATH)/decoder/parser.c
-uavs3d_srcs_c   += $(SRC_PATH)/decoder/dec_util.c
-
-LOCAL_CFLAGS    += -O3 -fPIC -std=gnu99
-LOCAL_LDFLAGS   += -fPIC
-
-#if build_executable
 LOCAL_CFLAGS    += -pie -fPIE
 LOCAL_LDFLAGS   += -pie -fPIE
-uavs3d_srcs_test+= $(SRC_PATH)/../test/utest.c  
-#endif
-
-#if build armv7a
-#LOCAL_CFLAGS 	+= -mfpu=neon
-#include $(LOCAL_PATH)/uavs3d_armv7a.mk
-#elif build arm64
-include $(LOCAL_PATH)/uavs3d_arm64.mk
-#endif
-
-LOCAL_SRC_FILES := $(uavs3d_srcs_c) $(uavs3d_srcs_arm) $(uavs3d_srcs_test)
-
-#include $(BUILD_SHARED_LIBRARY)
-#include $(BUILD_STATIC_LIBRARY)
+uavs3d_srcs_test+= $(SRC_PATH)/../test/utest.c
+include $(LOCAL_PATH)/uavs3d_main.mk
 include $(BUILD_EXECUTABLE)

--- a/build/android/ndk/jni/Application.mk
+++ b/build/android/ndk/jni/Application.mk
@@ -1,8 +1,9 @@
 # APP_ABI := armeabi-v7a
- APP_ABI := arm64-v8a
+# APP_ABI := arm64-v8a
 # APP_ABI := armeabi
 # APP_ABI := x86
 # APP_ABI := x86_64
+APP_ABI := all
  APP_OPTIM := release
 # TARGET_BUILD_TYPE=release
 

--- a/build/android/ndk/jni/uavs3d_avx2.mk
+++ b/build/android/ndk/jni/uavs3d_avx2.mk
@@ -1,0 +1,11 @@
+
+AVX_SRC_PATH:=../../../../source/decore/avx2
+
+uavs3d_srcs_avx  += $(AVX_SRC_PATH)/alf_avx2.c
+uavs3d_srcs_avx  += $(AVX_SRC_PATH)/avx2.c
+uavs3d_srcs_avx  += $(AVX_SRC_PATH)/inter_pred_avx2.c
+uavs3d_srcs_avx  += $(AVX_SRC_PATH)/intra_pred_avx2.c
+uavs3d_srcs_avx  += $(AVX_SRC_PATH)/itrans_avx2.c
+uavs3d_srcs_avx  += $(AVX_SRC_PATH)/pixel_avx2.c
+uavs3d_srcs_avx  += $(AVX_SRC_PATH)/sao_avx2.c
+

--- a/build/android/ndk/jni/uavs3d_clear_vars.mk
+++ b/build/android/ndk/jni/uavs3d_clear_vars.mk
@@ -1,0 +1,6 @@
+include $(CLEAR_VARS) 
+uavs3d_srcs_c :=
+uavs3d_srcs_test :=
+uavs3d_srcs_arm :=
+uavs3d_srcs_sse :=
+uavs3d_srcs_avx :=

--- a/build/android/ndk/jni/uavs3d_main.mk
+++ b/build/android/ndk/jni/uavs3d_main.mk
@@ -1,0 +1,55 @@
+
+### for posix pthread
+#LOCAL_SHARED_LIBRARIES := libcutil
+
+### include search path when compiling all sources (C,C++,Assembly)
+LOCAL_C_INCLUDES +=$(INCLUDE_PATH)                             \
+                   $(LOCAL_PATH)/../app           
+
+### c source code
+uavs3d_srcs_c   += $(SRC_PATH)/decore/alf.c
+uavs3d_srcs_c   += $(SRC_PATH)/decore/deblock.c
+uavs3d_srcs_c   += $(SRC_PATH)/decore/inter_pred.c
+uavs3d_srcs_c   += $(SRC_PATH)/decore/intra_pred.c
+uavs3d_srcs_c   += $(SRC_PATH)/decore/inv_trans.c
+uavs3d_srcs_c   += $(SRC_PATH)/decore/pic_manager.c
+uavs3d_srcs_c   += $(SRC_PATH)/decore/recon.c
+uavs3d_srcs_c   += $(SRC_PATH)/decore/sao.c
+uavs3d_srcs_c   += $(SRC_PATH)/decore/com_table.c
+uavs3d_srcs_c   += $(SRC_PATH)/decore/threadpool.c
+uavs3d_srcs_c   += $(SRC_PATH)/decore/win32thread.c
+uavs3d_srcs_c   += $(SRC_PATH)/decore/com_util.c
+uavs3d_srcs_c   += $(SRC_PATH)/decoder/uavs3d.c
+uavs3d_srcs_c   += $(SRC_PATH)/decoder/bitstream.c
+uavs3d_srcs_c   += $(SRC_PATH)/decoder/parser.c
+uavs3d_srcs_c   += $(SRC_PATH)/decoder/dec_util.c
+
+
+LOCAL_CFLAGS    += -O3 -fPIC -std=gnu99 -I../../../source/decore
+
+ifeq ($(TARGET_ARCH),arm)
+	# build armv7a
+	LOCAL_CFLAGS 	+= -mfpu=neon
+	include $(LOCAL_PATH)/uavs3d_armv7a.mk
+endif
+
+ifeq ($(TARGET_ARCH),arm64)
+	# build arm64
+	include $(LOCAL_PATH)/uavs3d_arm64.mk
+endif
+
+ifeq ($(TARGET_ARCH),x86)
+	# build x86
+	LOCAL_CFLAGS 	+= -msse4.2 -mavx2
+	include $(LOCAL_PATH)/uavs3d_sse2.mk
+	include $(LOCAL_PATH)/uavs3d_avx2.mk
+endif
+
+ifeq ($(TARGET_ARCH),x86_64)
+	# build x86_64
+	LOCAL_CFLAGS 	+= -msse4.2 -mavx2
+	include $(LOCAL_PATH)/uavs3d_sse2.mk
+	include $(LOCAL_PATH)/uavs3d_avx2.mk
+endif
+
+LOCAL_SRC_FILES := $(uavs3d_srcs_c) $(uavs3d_srcs_arm) $(uavs3d_srcs_sse) $(uavs3d_srcs_avx) $(uavs3d_srcs_test)

--- a/build/android/ndk/jni/uavs3d_sse2.mk
+++ b/build/android/ndk/jni/uavs3d_sse2.mk
@@ -1,0 +1,11 @@
+
+SSE_SRC_PATH:=../../../../source/decore/sse
+
+uavs3d_srcs_sse  += $(SSE_SRC_PATH)/alf_sse.c
+uavs3d_srcs_sse  += $(SSE_SRC_PATH)/deblock_sse.c
+uavs3d_srcs_sse  += $(SSE_SRC_PATH)/inter_pred_sse.c
+uavs3d_srcs_sse  += $(SSE_SRC_PATH)/intra_pred_sse.c
+uavs3d_srcs_sse  += $(SSE_SRC_PATH)/itrans_sse.c
+uavs3d_srcs_sse  += $(SSE_SRC_PATH)/pixel_sse.c
+uavs3d_srcs_sse  += $(SSE_SRC_PATH)/sao_sse.c
+uavs3d_srcs_sse  += $(SSE_SRC_PATH)/sse.c

--- a/source/decore/sse/sse.h
+++ b/source/decore/sse/sse.h
@@ -45,9 +45,8 @@
 
 #include "modules.h"
 
-#ifdef _WIN32
-
-#ifndef _WIN64
+#if __x86_64__
+#elif	__i386__
 #include <stdint.h>
 static inline int64_t _mm_extract_epi64(__m128i a, const int imm8) {
     return imm8 ? ((int64_t)_mm_extract_epi16(a, 7) << 48) |
@@ -57,8 +56,6 @@ static inline int64_t _mm_extract_epi64(__m128i a, const int imm8) {
                       ((int64_t)_mm_extract_epi16(a, 2) << 32) |
                       (_mm_extract_epi16(a, 1) << 16) | _mm_extract_epi16(a, 0);
 }
-#endif
-
 #endif
 
 ALIGNED_32(extern pel uavs3d_simd_mask[15][16]);


### PR DESCRIPTION
modify android ndk-build scripts support executable/static library/shared library to be built on all platforms

// build all
ndk-build

// build binary
ndk-build uavs3d

// build shared library
ndk-build uavs3d-shared

// build static library
ndk-build uavs3d-static
