### PR TITLE
_mm_extract_epi64: only define our own if it's not already defined

### DIFF
--- a/source/decore/sse/sse.h
+++ b/source/decore/sse/sse.h
@@ -41,7 +41,8 @@
 #include "modules.h"
 
 #if __x86_64__
-#elif	__i386__
+#elif __i386__ && !defined(_mm_extract_epi64)
+#define _mm_extract_epi64 _mm_extract_epi64
 #include <stdint.h>
 static inline int64_t _mm_extract_epi64(__m128i a, const int imm8) {
     return imm8 ? ((int64_t)_mm_extract_epi16(a, 7) << 48) |


### PR DESCRIPTION
LLVM 15 added this function for 32-bit, so defining our own instead causes a compilation error.

https://github.com/llvm/llvm-project/commit/afa536e33e10536380ccf67732fa3a101facab92

Signed-off-by: Christopher Degawa <ccom@randomderp.com>